### PR TITLE
0.5.0 updates

### DIFF
--- a/openet/geesebal/model.py
+++ b/openet/geesebal/model.py
@@ -28,9 +28,6 @@ def et(
     geometry_image,
     proj,
     coords,
-    #et_reference,
-    cold_calibration_points=1,
-    hot_calibration_points=1,
     max_iterations=15,
 ):
     """
@@ -40,6 +37,8 @@ def et(
     ----------
     image : ee.Image
         Landsat image.
+    lai : ee.Image
+        Leaf area index.
     ndvi : ee.Image
         Normalized difference vegetation index.
     ndwi : ee.Image
@@ -73,10 +72,6 @@ def et(
         Landsat image projection.
     coords : ee.Image
         Landsat image Latitude and longitude.
-    cold_calibration_points : int
-        Number of cold pixel calibration points (the default is 10).
-    hot_calibration_points : int
-        Number of hot pixel calibration points (the default is 10).
     max_iterations : int
         Maximum number of iterations (the default is 15).
 
@@ -95,8 +90,8 @@ def et(
 
     """
     # Fixed calibration points
-    cold_calibration_points=1
-    hot_calibration_points=1
+    cold_calibration_points = 1
+    hot_calibration_points = 1
 
     # Image properties
     date = ee.Date(time_start)
@@ -972,7 +967,7 @@ def cold_pixel(
     dem : ee.Image
         Elevation data [m].
     calibration_points : int
-        Number of calibration points (the default is 10).
+        Number of calibration points (the default is 1).
 
     Returns
     -------
@@ -1101,6 +1096,7 @@ def cold_pixel(
     
     return cold_pixels_table
 
+
 def radiation_inst(dem, lst, emissivity, albedo, tair, rh, swdown_inst, sun_elevation, cos_terrain):
     """
     Instantaneous Net Radiation [W m-2]
@@ -1170,6 +1166,7 @@ def radiation_inst(dem, lst, emissivity, albedo, tair, rh, swdown_inst, sun_elev
     )
 
     return rn_inst.rename("rn_inst")
+
 
 def soil_heat_flux(rn, ndvi, albedo, lst_dem, ndwi, year, country='USA'):
     """
@@ -1265,6 +1262,7 @@ def soil_heat_flux(rn, ndvi, albedo, lst_dem, ndwi, year, country='USA'):
     g = g.where(ndwi.gt(0), rn.multiply(0.5))
 
     return g.rename("g_inst")
+
 
 def radiation_24h(time_start, tmax, tmin, elev, sun_elevation, cos_terrain, rso24h):
     """
@@ -1408,7 +1406,7 @@ def hot_pixel(
     proj : ee.Dictionary
         Landsat image projection.
     calibration_points : int
-        Number of calibration points (the default is 10).
+        Number of calibration points (the default is 1).
 
     Returns
     -------

--- a/openet/geesebal/openet_image.py
+++ b/openet/geesebal/openet_image.py
@@ -89,10 +89,6 @@ class Image:
             et_reference_resample : {'nearest', 'bilinear', 'bicubic', None}
                 Reference ET resampling.  The default is None which is
                 equivalent to nearest neighbor resampling.
-            cold_calibration_points : int
-                Number of cold calibration points (the default is 1).
-            hot_calibration_points : int
-                Number of hot calibration points (the default is 1).
             max_iterations : int
                 Maximum number of iterations (the default is 15).
 
@@ -174,16 +170,6 @@ class Image:
         # Image projection and geotransform
         self.crs = image.projection().crs()
         self.transform = ee.List(ee.Dictionary(ee.Algorithms.Describe(image.projection())).get("transform"))
-
-        # CGM - Testing out passing as a kwargs but could be dedicated function params
-        try:
-            self.cold_calibration_points = kwargs["cold_calibration_points"]
-        except:
-            self.cold_calibration_points = 1
-        try:
-            self.hot_calibration_points = kwargs["hot_calibration_points"]
-        except:
-            self.hot_calibration_points = 1
 
         try:
             self.max_iterations = kwargs["max_iterations"]
@@ -480,13 +466,13 @@ class Image:
 
         et = model.et(
             image=self.image,
+            lai=self.lai,
             ndvi=self.ndvi,
             ndwi=self.ndwi,
             lst=self.lst,
             albedo=self.albedo,
             emissivity=self.emissivity,
             savi=self.savi,
-            # lai=self.lai,
             meteorology_source_inst=self._meteorology_source_inst,
             meteorology_source_daily=self._meteorology_source_daily,
             elev_product=self._elev_source,
@@ -499,8 +485,6 @@ class Image:
             proj=self.proj,
             coords=self.coords,
             #et_reference = self.et_reference,
-            cold_calibration_points=self.cold_calibration_points,
-            hot_calibration_points=self.hot_calibration_points,
             max_iterations=self.max_iterations,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openet-geesebal"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     { name = "Anderson Ruhoff", email = "andersonruhoff@gmail.com" },
     { name = "Leonardo Laipelt", email = "leolaipelt@gmail.com" },


### PR DESCRIPTION
@leolaipelt @matterios I was trying to run the new 0.5.0 branch and noticed a couple of issues.

Adding lai to doc string and model.et() call.

Updating version number in pyproject.toml.

Removing calibration point parameters from model.et() call and the Image class since the number of calibration points is now hardcoded to 1 in the model.